### PR TITLE
Add comprehensive voting tests and finalize_proposal logic

### DIFF
--- a/programs/mostro_program/src/error.rs
+++ b/programs/mostro_program/src/error.rs
@@ -3,15 +3,11 @@ use anchor_lang::prelude::*;
 #[error_code]
 pub enum ErrorCode {
 	#[msg("Only the admin can perform this action.")]
-    UnauthorizedAdmin,
+  UnauthorizedAdmin,
 	#[msg("Unauthorized access")]
 	Unauthorized,
 	#[msg("Percentages must sum to 100")]
 	InvalidPercentage,
-	#[msg("Proposal is not active")]
-	ProposalNotActive,
-	#[msg("Proposal has expired")]
-	ProposalExpired,
 	#[msg("User has already voted on this proposal")]
 	AlreadyVoted,
 	#[msg("Insufficient tokens for operation")]
@@ -26,8 +22,14 @@ pub enum ErrorCode {
 	InvalidTokenAmount,
 	#[msg("Invalid SOL amount")]
 	InvalidSolAmount,
-	#[msg("Error in bonding curve calculation")]
-	BondingCurveError,
 	#[msg("No voting power (no tokens held)")]
 	NoVotingPower,
+	#[msg("Voting period has already ended.")]
+  VotingEnded,
+  #[msg("Arithmetic overflow occurred.")]
+  Overflow,
+  #[msg("Voting period is still active.")]
+  VotingStillActive,
+  #[msg("Invalid instruction data.")]
+  InvalidInstructionData,
 }

--- a/programs/mostro_program/src/instructions/finalize_proposal.rs
+++ b/programs/mostro_program/src/instructions/finalize_proposal.rs
@@ -1,0 +1,58 @@
+#![allow(unexpected_cfgs)] // Suppress warnings from Anchor macros (e.g., #[cfg(anchor-debug)])
+
+use anchor_lang::prelude::*;
+use crate::error::ErrorCode;
+use crate::state::Proposal;
+
+#[derive(Accounts)]
+#[instruction(name: String, proposal_id: u64)]
+pub struct FinalizeProposal<'info> {
+    /// Any user can call to finalize after the voting period
+    #[account(mut)]
+    pub caller: Signer<'info>,
+
+    /// Proposal PDA to finalize
+    #[account(
+        mut,
+        seeds = [
+            b"artist_proposal",
+            name.as_bytes().as_ref(),
+            proposal_id.to_le_bytes().as_ref()
+        ],
+        bump = proposal.bump
+    )]
+    pub proposal: Account<'info, Proposal>,
+}
+
+pub fn finalize_proposal_handler(
+    ctx: Context<FinalizeProposal>,
+    _name: String,
+    _proposal_id: u64,
+) -> Result<()> {
+    let proposal = &mut ctx.accounts.proposal;
+    let clock = Clock::get()?;
+
+    // Ensure voting period has ended
+    require!(
+        clock.unix_timestamp >= proposal.end_date,
+        ErrorCode::VotingStillActive
+    );
+
+    let total_votes = proposal.yes_votes + proposal.no_votes;
+
+    // Quorum: at least 10% of total tokens must participate
+    let quorum = proposal.number_of_tokens / 10; // 10%
+    if total_votes < quorum {
+        proposal.status = 2; // Rejected due to low participation
+        return Ok(());
+    }
+
+    // Approval threshold: 51% yes votes
+    if proposal.yes_votes * 100 / total_votes >= 51 {
+        proposal.status = 1; // Approved
+    } else {
+        proposal.status = 2; // Rejected
+    }
+
+    Ok(())
+}

--- a/programs/mostro_program/src/instructions/mod.rs
+++ b/programs/mostro_program/src/instructions/mod.rs
@@ -5,6 +5,7 @@ pub mod create_artist;
 pub mod create_config;
 pub mod create_proposal;
 pub mod vote_proposal;
+pub mod finalize_proposal;
 pub mod release_tokens;
 
 // -----------------------------
@@ -15,4 +16,5 @@ pub use create_artist::*; // create_artist_handler, CreateArtist
 pub use create_config::*; // create_config_handler, CreateConfig
 pub use create_proposal::*; // create_proposal_handler, CreateProposal
 pub use vote_proposal::*; // vote_on_proposal_handler, VoteOnProposal
+pub use finalize_proposal::*; // finalize_proposal_handler, FinalizeProposal
 pub use release_tokens::*; // release_tokens_to_artist_handler, ReleaseTokensToArtist

--- a/programs/mostro_program/src/lib.rs
+++ b/programs/mostro_program/src/lib.rs
@@ -61,6 +61,14 @@ pub mod mostro_program {
         vote_proposal_handler(ctx, name, proposal_id, vote_choice)
     }
 
+    pub fn finalize_proposal(
+        ctx: Context<FinalizeProposal>,
+        name: String,
+        proposal_id: u64,
+    ) -> Result<()> {
+        finalize_proposal_handler(ctx, name, proposal_id)
+    }
+
     // -----------------------------
     // Artist Management
     // -----------------------------


### PR DESCRIPTION
- Ensure only eligible voters (token holders) can vote
- Test prevention of double voting for the same proposal
- Simulate multiple voters and verify yes/no tallies and total voting power
- Test status transition via finalize_proposal after voting period ends
- Add test to verify quorum and threshold logic for proposals